### PR TITLE
Local start time and timezone for Windows

### DIFF
--- a/lib/SoftwareUtil.py
+++ b/lib/SoftwareUtil.py
@@ -27,6 +27,7 @@ sessionMap = {}
 
 runningResourceCmd = False
 loggedInCacheState = False
+timezone=''
 
 # log the message.
 def log(message):
@@ -53,21 +54,24 @@ def getOs():
 
 def getTimezone():
     try:
-        if time.tzname[1] is None or time.tzname[0] == time.tzname[1]:
+        timezone = time.localtime().tm_zone
+#         if time.tzname[1] is None or time.tzname[0] == time.tzname[1]:
             # no DST
-            timezone = time.tzname[0]
-        else:
+#             timezone = time.tzname[0]
+#         else:
             # we're in DST
-            timezone = time.tzname[1]
+#             timezone = time.tzname[1]
     except Exception:
-        keystrokeCountObj.timezone = ''
+        pass
+#         keystrokeCountObj.timezone = ''
     return timezone
 
 def getLocalStart():
     now = round(time.time())
     local_start = now - time.timezone
     try:
-        if time.tzname[1] is None or time.tzname[0] == time.tzname[1]:
+        if time.localtime().tm_isdst == 0:
+#         if time.tzname[1] is None or time.tzname[0] == time.tzname[1]:
             # no DST, use the local_start based on time.timezone
             pass
         else:


### PR DESCRIPTION
Instead of using `time.tzname()` to get time zone, we can use `time.localtime().tm_isdst` and look at the tm_isdst flag in the return value that could tell us whether the DST is in effect or not.

now = time.localtime()
print(now)

`time.struct_time(tm_year=2019, tm_mon=8, tm_mday=12, tm_hour=18, tm_min=12, tm_sec=17, tm_wday=0, tm_yday=224, tm_isdst=0)`

print(now.tm_zone)
`India Standard Time`