### PR TITLE
SFTW-2336 : Timezone display issue solved in windows

### DIFF
--- a/lib/SoftwareUtil.py
+++ b/lib/SoftwareUtil.py
@@ -55,10 +55,10 @@ def getOs():
 def getTimezone():
     global timezone
     try:
-        timezone = time.localtime().tm_zone
+        timezone = datetime.datetime.now(datetime.timezone.utc).astimezone().tzname()
     except Exception:
         pass
-#         keystrokeCountObj.timezone = ''
+        keystrokeCountObj.timezone = ''
     return timezone
 
 def getLocalStart():


### PR DESCRIPTION
This is currently happening in the windows sublime. console. This code will work fine on Python interpreter but it throws an error when you type in sublime console.
```
>>>import time
>>> timezone = time.localtime().tm_zone
Traceback (most recent call last):
  File "<string>", line 1, in <module>
AttributeError: 'time.struct_time' object has no attribute 'tm_zone'
```
We can fix this issue with alternative syntax for getting time zone

```
import time
import datetime
timezone = datetime.datetime.now(datetime.timezone.utc).astimezone().tzname()
```