### PR TITLE
ensure the unfocus value is set and fix checking if theres data

### DIFF
--- a/Software.py
+++ b/Software.py
@@ -180,11 +180,14 @@ def check_and_send_unfocus_event(view):
     global editor_focused
     global last_focus_event_sent
 
-    if(editor_focused is False and last_focus_event_sent is not 'unfocus'):
-        # this will send off codetime events
-        PluginData.send_all_datas()
-        track_editor_action(**editor_action_params(view, 'editor', 'unfocus'))
-        last_focus_event_sent = 'unfocus'
+    if (editor_focused is False):
+        # set the 'isFocused' value within the SoftwareWallClock to False
+        blurWindow()
+        if (last_focus_event_sent is not 'unfocus'):
+            # this will send off codetime events
+            PluginData.send_all_datas()
+            track_editor_action(**editor_action_params(view, 'editor', 'unfocus'))
+            last_focus_event_sent = 'unfocus'
 
 # Runs once instance per view (i.e. tab, or single file window)
 class EventListener(sublime_plugin.EventListener):
@@ -213,6 +216,8 @@ class EventListener(sublime_plugin.EventListener):
         fileInfoData['length'] = get_character_count(view)
         fileInfoData['lines'] = get_line_count(view)
 
+    # this is called when the plugin initializes and
+    # when it's deactivated (put into the background)
     def on_deactivated_async(self, view):
         blurWindow()
         global editor_focused

--- a/lib/KpmManager.py
+++ b/lib/KpmManager.py
@@ -129,13 +129,13 @@ class PluginData():
                 return True
         return False
 
+    # Return True if a keystroke payload has keystrokes
     @staticmethod
     def hasKeystrokeData():
         for dir in PluginData.active_datas:
             keystrokeCountObj = PluginData.active_datas[dir]
-            if keystrokeCountObj is not None and keystrokeCountObj.source is not None:
-                # check if the source object is empty
-                if bool(keystrokeCountObj.source):
+            if keystrokeCountObj is not None and keystrokeCountObj.keystrokes is not None:
+                if keystrokeCountObj.keystrokes > 0:
                     return True
         return False
 

--- a/lib/SoftwareWallClock.py
+++ b/lib/SoftwareWallClock.py
@@ -49,13 +49,6 @@ def setWcTime(seconds):
     setItem('wctime', seconds)
     updateWcTime()
 
-def updateBasedOnSessionSeconds(session_seconds):
-    editor_seconds = getWcTimeInSeconds()
-
-    if editor_seconds < session_seconds:
-        editor_seconds = session_seconds + 1
-        setWcTime(editor_seconds)
-
 def focusWindow():
     global isFocused
     isFocused = True


### PR DESCRIPTION
the wallclock manager is updating the wallclock time every 30 seconds even if there's no data and not focused.

* it should only update the wallclock time if...
  - it has data and is unfocused (an event that happens when a user finishes typing then focuses another app window)
  - or if the window is focused